### PR TITLE
flake: update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1732483221,
-        "narHash": "sha256-kF6rDeCshoCgmQz+7uiuPdREVFuzhIorGOoPXMalL2U=",
+        "lastModified": 1735388221,
+        "narHash": "sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "45348ad6fb8ac0e8415f6e5e96efe47dd7f39405",
+        "rev": "7c674c6734f61157e321db595dbfcd8523e04e19",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733951536,
-        "narHash": "sha256-Zb5ZCa7Xj+0gy5XVXINTSr71fCfAv+IKtmIXNrykT54=",
+        "lastModified": 1735344290,
+        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f",
+        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732519917,
-        "narHash": "sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q=",
+        "lastModified": 1736047960,
+        "narHash": "sha256-hutd85FA1jUJhhqBRRJ+u7UHO9oFGD/RVm2x5w8WjVQ=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f4a5ca5771ba9ca31ad24a62c8d511a405303436",
+        "rev": "816a6ae88774ba7e74314830546c29e134e0dffb",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733808091,
-        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
+        "lastModified": 1735922141,
+        "narHash": "sha256-vk0xwGZSlvZ/596yxOtsk4gxsIx2VemzdjiU8zhjgWw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
+        "rev": "d29ab98cd4a70a387b8ceea3e930b3340d41ac5a",
         "type": "github"
       },
       "original": {
@@ -151,29 +151,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1735834308,
+        "narHash": "sha256-dklw3AXr3OGO4/XT1Tu3Xz9n/we8GctZZ75ZWVqAVhk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "6df24922a1400241dae323af55f30e4318a6ca65",
         "type": "github"
       },
       "original": {
@@ -198,11 +182,11 @@
         "treefmt-nix": []
       },
       "locked": {
-        "lastModified": 1733953808,
-        "narHash": "sha256-qJUFJC2jzBcK9r1FcfAuZkx9IPOBOA5wgpwlZnMWABw=",
+        "lastModified": 1735993984,
+        "narHash": "sha256-Syew+5yuzysUr07SrGD+GRfZjE11h36TSYbxzEHYyyc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "02505f24b518e453bf523d235e6eed6c71f28142",
+        "rev": "6bd1c7c5927fa9fdfdfd68f5aa772e6a62b9d779",
         "type": "github"
       },
       "original": {
@@ -218,15 +202,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs-unstable"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1735882644,
+        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
         "type": "github"
       },
       "original": {
@@ -255,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732894027,
-        "narHash": "sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII+oAc=",
+        "lastModified": 1735905407,
+        "narHash": "sha256-1hKMRIT+QZNWX46e4gIovoQ7H8QRb7803ZH4qSKI45o=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6209c381904cab55796c5d7350e89681d3b2a8ef",
+        "rev": "29806abab803e498df96d82dd6f34b32eb8dd2c8",
         "type": "github"
       },
       "original": {

--- a/hosts/alderaan/default.nix
+++ b/hosts/alderaan/default.nix
@@ -27,9 +27,12 @@
   boot.initrd.secrets = {
     "/crypto_keyfile.bin" = null;
   };
-  boot.initrd.luks.devices."luks-4af00ef3-9f52-4447-9f2b-fcffedb33cde".device = "/dev/disk/by-uuid/4af00ef3-9f52-4447-9f2b-fcffedb33cde";
-  boot.initrd.luks.devices."luks-47d56822-d64c-4b0d-b454-b1cbf08d3b7c".device = "/dev/disk/by-uuid/47d56822-d64c-4b0d-b454-b1cbf08d3b7c";
-  boot.initrd.luks.devices."luks-47d56822-d64c-4b0d-b454-b1cbf08d3b7c".keyFile = "/crypto_keyfile.bin";
+  boot.initrd.luks.devices."luks-4af00ef3-9f52-4447-9f2b-fcffedb33cde".device =
+    "/dev/disk/by-uuid/4af00ef3-9f52-4447-9f2b-fcffedb33cde";
+  boot.initrd.luks.devices."luks-47d56822-d64c-4b0d-b454-b1cbf08d3b7c".device =
+    "/dev/disk/by-uuid/47d56822-d64c-4b0d-b454-b1cbf08d3b7c";
+  boot.initrd.luks.devices."luks-47d56822-d64c-4b0d-b454-b1cbf08d3b7c".keyFile =
+    "/crypto_keyfile.bin";
   boot.initrd.availableKernelModules = [
     "xhci_pci"
     "ehci_pci"


### PR DESCRIPTION
Created by [action-nix-flake-update](https://github.com/dawidd6/action-nix-flake-update).

```sh
• Updated input 'hardware':
    'github:nixos/nixos-hardware/45348ad6fb8ac0e8415f6e5e96efe47dd7f39405?narHash=sha256-kF6rDeCshoCgmQz%2B7uiuPdREVFuzhIorGOoPXMalL2U%3D' (2024-11-24)
  → 'github:nixos/nixos-hardware/7c674c6734f61157e321db595dbfcd8523e04e19?narHash=sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg%3D' (2024-12-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f?narHash=sha256-Zb5ZCa7Xj%2B0gy5XVXINTSr71fCfAv%2BIKtmIXNrykT54%3D' (2024-12-11)
  → 'github:nix-community/home-manager/613691f285dad87694c2ba1c9e6298d04736292d?narHash=sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM%3D' (2024-12-28)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f4a5ca5771ba9ca31ad24a62c8d511a405303436?narHash=sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q%3D' (2024-11-25)
  → 'github:nix-community/nix-index-database/816a6ae88774ba7e74314830546c29e134e0dffb?narHash=sha256-hutd85FA1jUJhhqBRRJ%2Bu7UHO9oFGD/RVm2x5w8WjVQ%3D' (2025-01-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e?narHash=sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk%3D' (2024-12-10)
  → 'github:nixos/nixpkgs/d29ab98cd4a70a387b8ceea3e930b3340d41ac5a?narHash=sha256-vk0xwGZSlvZ/596yxOtsk4gxsIx2VemzdjiU8zhjgWw%3D' (2025-01-03)
• Updated input 'nixpkgs-unstable':
    'github:nixos/nixpkgs/970e93b9f82e2a0f3675757eb0bfc73297cc6370?narHash=sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE%3D' (2024-11-28)
  → 'github:nixos/nixpkgs/6df24922a1400241dae323af55f30e4318a6ca65?narHash=sha256-dklw3AXr3OGO4/XT1Tu3Xz9n/we8GctZZ75ZWVqAVhk%3D' (2025-01-02)
• Updated input 'nixvim':
    'github:nix-community/nixvim/02505f24b518e453bf523d235e6eed6c71f28142?narHash=sha256-qJUFJC2jzBcK9r1FcfAuZkx9IPOBOA5wgpwlZnMWABw%3D' (2024-12-11)
  → 'github:nix-community/nixvim/6bd1c7c5927fa9fdfdfd68f5aa772e6a62b9d779?narHash=sha256-Syew%2B5yuzysUr07SrGD%2BGRfZjE11h36TSYbxzEHYyyc%3D' (2025-01-04)
• Updated input 'pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c?narHash=sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE%3D' (2024-11-19)
  → 'github:cachix/pre-commit-hooks.nix/a5a961387e75ae44cc20f0a57ae463da5e959656?narHash=sha256-3FZAG%2BpGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110%3D' (2025-01-03)
• Removed input 'pre-commit-hooks/nixpkgs-stable'
• Updated input 'treefmt':
    'github:numtide/treefmt-nix/6209c381904cab55796c5d7350e89681d3b2a8ef?narHash=sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII%2BoAc%3D' (2024-11-29)
  → 'github:numtide/treefmt-nix/29806abab803e498df96d82dd6f34b32eb8dd2c8?narHash=sha256-1hKMRIT%2BQZNWX46e4gIovoQ7H8QRb7803ZH4qSKI45o%3D' (2025-01-03)
```

- [`hardware@45348ad...7c674c6`](https://github.com/nixos/nixos-hardware/compare/45348ad6fb8ac0e8415f6e5e96efe47dd7f39405...7c674c6734f61157e321db595dbfcd8523e04e19)
- [`home-manager@1318c3f...613691f`](https://github.com/nix-community/home-manager/compare/1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f...613691f285dad87694c2ba1c9e6298d04736292d)
- [`nix-index-database@f4a5ca5...816a6ae`](https://github.com/nix-community/nix-index-database/compare/f4a5ca5771ba9ca31ad24a62c8d511a405303436...816a6ae88774ba7e74314830546c29e134e0dffb)
- [`nixpkgs@a0f3e10...d29ab98`](https://github.com/nixos/nixpkgs/compare/a0f3e10d94359665dba45b71b4227b0aeb851f8e...d29ab98cd4a70a387b8ceea3e930b3340d41ac5a)
- [`nixpkgs-unstable@970e93b...6df2492`](https://github.com/nixos/nixpkgs/compare/970e93b9f82e2a0f3675757eb0bfc73297cc6370...6df24922a1400241dae323af55f30e4318a6ca65)
- [`nixvim@02505f2...6bd1c7c`](https://github.com/nix-community/nixvim/compare/02505f24b518e453bf523d235e6eed6c71f28142...6bd1c7c5927fa9fdfdfd68f5aa772e6a62b9d779)
- [`pre-commit-hooks@3308484...a5a9613`](https://github.com/cachix/pre-commit-hooks.nix/compare/3308484d1a443fc5bc92012435d79e80458fe43c...a5a961387e75ae44cc20f0a57ae463da5e959656)
- [`treefmt@6209c38...29806ab`](https://github.com/numtide/treefmt-nix/compare/6209c381904cab55796c5d7350e89681d3b2a8ef...29806abab803e498df96d82dd6f34b32eb8dd2c8)