### PR TITLE
flake: update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1732483221,
-        "narHash": "sha256-kF6rDeCshoCgmQz+7uiuPdREVFuzhIorGOoPXMalL2U=",
+        "lastModified": 1736283893,
+        "narHash": "sha256-BG1FfTexFwNty5VhYjaQLMR6CMPfI3QRcaZrFQYu2EM=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "45348ad6fb8ac0e8415f6e5e96efe47dd7f39405",
+        "rev": "4f339f6be2b61662f957c2ee9eda0fa597d8a6d6",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733951536,
-        "narHash": "sha256-Zb5ZCa7Xj+0gy5XVXINTSr71fCfAv+IKtmIXNrykT54=",
+        "lastModified": 1735344290,
+        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f",
+        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732519917,
-        "narHash": "sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q=",
+        "lastModified": 1736047960,
+        "narHash": "sha256-hutd85FA1jUJhhqBRRJ+u7UHO9oFGD/RVm2x5w8WjVQ=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f4a5ca5771ba9ca31ad24a62c8d511a405303436",
+        "rev": "816a6ae88774ba7e74314830546c29e134e0dffb",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733808091,
-        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
+        "lastModified": 1736200483,
+        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
+        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
         "type": "github"
       },
       "original": {
@@ -151,29 +151,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {
@@ -198,11 +182,11 @@
         "treefmt-nix": []
       },
       "locked": {
-        "lastModified": 1733953808,
-        "narHash": "sha256-qJUFJC2jzBcK9r1FcfAuZkx9IPOBOA5wgpwlZnMWABw=",
+        "lastModified": 1735993984,
+        "narHash": "sha256-Syew+5yuzysUr07SrGD+GRfZjE11h36TSYbxzEHYyyc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "02505f24b518e453bf523d235e6eed6c71f28142",
+        "rev": "6bd1c7c5927fa9fdfdfd68f5aa772e6a62b9d779",
         "type": "github"
       },
       "original": {
@@ -218,15 +202,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs-unstable"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1735882644,
+        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
         "type": "github"
       },
       "original": {
@@ -255,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732894027,
-        "narHash": "sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII+oAc=",
+        "lastModified": 1736154270,
+        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6209c381904cab55796c5d7350e89681d3b2a8ef",
+        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
         "type": "github"
       },
       "original": {

--- a/hosts/alderaan/default.nix
+++ b/hosts/alderaan/default.nix
@@ -27,9 +27,12 @@
   boot.initrd.secrets = {
     "/crypto_keyfile.bin" = null;
   };
-  boot.initrd.luks.devices."luks-4af00ef3-9f52-4447-9f2b-fcffedb33cde".device = "/dev/disk/by-uuid/4af00ef3-9f52-4447-9f2b-fcffedb33cde";
-  boot.initrd.luks.devices."luks-47d56822-d64c-4b0d-b454-b1cbf08d3b7c".device = "/dev/disk/by-uuid/47d56822-d64c-4b0d-b454-b1cbf08d3b7c";
-  boot.initrd.luks.devices."luks-47d56822-d64c-4b0d-b454-b1cbf08d3b7c".keyFile = "/crypto_keyfile.bin";
+  boot.initrd.luks.devices."luks-4af00ef3-9f52-4447-9f2b-fcffedb33cde".device =
+    "/dev/disk/by-uuid/4af00ef3-9f52-4447-9f2b-fcffedb33cde";
+  boot.initrd.luks.devices."luks-47d56822-d64c-4b0d-b454-b1cbf08d3b7c".device =
+    "/dev/disk/by-uuid/47d56822-d64c-4b0d-b454-b1cbf08d3b7c";
+  boot.initrd.luks.devices."luks-47d56822-d64c-4b0d-b454-b1cbf08d3b7c".keyFile =
+    "/crypto_keyfile.bin";
   boot.initrd.availableKernelModules = [
     "xhci_pci"
     "ehci_pci"


### PR DESCRIPTION
Output of `nix flake update`:
```
warning: updating lock file '/home/runner/work/nixcfg/nixcfg/flake.lock':
• Updated input 'hardware':
    'github:nixos/nixos-hardware/45348ad6fb8ac0e8415f6e5e96efe47dd7f39405?narHash=sha256-kF6rDeCshoCgmQz%2B7uiuPdREVFuzhIorGOoPXMalL2U%3D' (2024-11-24)
  → 'github:nixos/nixos-hardware/4f339f6be2b61662f957c2ee9eda0fa597d8a6d6?narHash=sha256-BG1FfTexFwNty5VhYjaQLMR6CMPfI3QRcaZrFQYu2EM%3D' (2025-01-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f?narHash=sha256-Zb5ZCa7Xj%2B0gy5XVXINTSr71fCfAv%2BIKtmIXNrykT54%3D' (2024-12-11)
  → 'github:nix-community/home-manager/613691f285dad87694c2ba1c9e6298d04736292d?narHash=sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM%3D' (2024-12-28)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f4a5ca5771ba9ca31ad24a62c8d511a405303436?narHash=sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q%3D' (2024-11-25)
  → 'github:nix-community/nix-index-database/816a6ae88774ba7e74314830546c29e134e0dffb?narHash=sha256-hutd85FA1jUJhhqBRRJ%2Bu7UHO9oFGD/RVm2x5w8WjVQ%3D' (2025-01-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e?narHash=sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk%3D' (2024-12-10)
  → 'github:nixos/nixpkgs/3f0a8ac25fb674611b98089ca3a5dd6480175751?narHash=sha256-JO%2BlFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I%3D' (2025-01-06)
• Updated input 'nixpkgs-unstable':
    'github:nixos/nixpkgs/970e93b9f82e2a0f3675757eb0bfc73297cc6370?narHash=sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE%3D' (2024-11-28)
  → 'github:nixos/nixpkgs/8f3e1f807051e32d8c95cd12b9b421623850a34d?narHash=sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs%2BrI%3D' (2025-01-04)
• Updated input 'nixvim':
    'github:nix-community/nixvim/02505f24b518e453bf523d235e6eed6c71f28142?narHash=sha256-qJUFJC2jzBcK9r1FcfAuZkx9IPOBOA5wgpwlZnMWABw%3D' (2024-12-11)
  → 'github:nix-community/nixvim/6bd1c7c5927fa9fdfdfd68f5aa772e6a62b9d779?narHash=sha256-Syew%2B5yuzysUr07SrGD%2BGRfZjE11h36TSYbxzEHYyyc%3D' (2025-01-04)
• Updated input 'pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c?narHash=sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE%3D' (2024-11-19)
  → 'github:cachix/pre-commit-hooks.nix/a5a961387e75ae44cc20f0a57ae463da5e959656?narHash=sha256-3FZAG%2BpGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110%3D' (2025-01-03)
• Removed input 'pre-commit-hooks/nixpkgs-stable'
• Updated input 'treefmt':
    'github:numtide/treefmt-nix/6209c381904cab55796c5d7350e89681d3b2a8ef?narHash=sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII%2BoAc%3D' (2024-11-29)
  → 'github:numtide/treefmt-nix/13c913f5deb3a5c08bb810efd89dc8cb24dd968b?narHash=sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw%3D' (2025-01-06)
```

Output of `nix fmt`:
```
2025/01/08 16:42:52 INFO using config file: /nix/store/9711i71whzwnv22xl7l3m3kvhdgbmb9d-treefmt.toml
WARN no formatter for path: .envrc
WARN no formatter for path: .github/dependabot.yml
WARN no formatter for path: .github/workflows/build.yml
WARN no formatter for path: .github/workflows/update.yml
WARN no formatter for path: .vscode/settings.json
WARN no formatter for path: README.md
WARN no formatter for path: scripts/1250-to-utf
WARN no formatter for path: scripts/biggest-files
WARN no formatter for path: scripts/decrypt-pdfs
WARN no formatter for path: scripts/delete-line-recursively
WARN no formatter for path: scripts/git-add-upstream
WARN no formatter for path: scripts/git-apply-patch-from-url
WARN no formatter for path: scripts/git-backport
WARN no formatter for path: scripts/git-checkout-with-remote
WARN no formatter for path: scripts/git-compare
WARN no formatter for path: scripts/git-fetch-all
WARN no formatter for path: scripts/git-is-dirty
WARN no formatter for path: scripts/git-multi
WARN no formatter for path: scripts/git-pr-checkout
WARN no formatter for path: scripts/git-prune-gone-branches
WARN no formatter for path: scripts/git-prune-local-branches-not-on-remote
WARN no formatter for path: scripts/git-retag
WARN no formatter for path: scripts/git-rm-branch-for-good
WARN no formatter for path: scripts/incus-from-iso
WARN no formatter for path: scripts/nix-flake-build-diff
WARN no formatter for path: scripts/nix-flake-compare
WARN no formatter for path: scripts/replace-recursively
WARN no formatter for path: scripts/scan-hosts-by-port
WARN no formatter for path: scripts/scan-ports-by-host
WARN no formatter for path: scripts/sha256sum-remote
WARN no formatter for path: scripts/trim-video
WARN no formatter for path: scripts/utf-to-1250
traversed 77 files
emitted 43 files for processing
formatted 43 files (1 changed) in 1.43s
```

Comparison URLs:
- [**hardware**@*45348ad...4f339f6*](https://github.com/nixos/nixos-hardware/compare/45348ad6fb8ac0e8415f6e5e96efe47dd7f39405...4f339f6be2b61662f957c2ee9eda0fa597d8a6d6)
- [**home-manager**@*1318c3f...613691f*](https://github.com/nix-community/home-manager/compare/1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f...613691f285dad87694c2ba1c9e6298d04736292d)
- [**nix-index-database**@*f4a5ca5...816a6ae*](https://github.com/nix-community/nix-index-database/compare/f4a5ca5771ba9ca31ad24a62c8d511a405303436...816a6ae88774ba7e74314830546c29e134e0dffb)
- [**nixpkgs**@*a0f3e10...3f0a8ac*](https://github.com/nixos/nixpkgs/compare/a0f3e10d94359665dba45b71b4227b0aeb851f8e...3f0a8ac25fb674611b98089ca3a5dd6480175751)
- [**nixpkgs-unstable**@*970e93b...8f3e1f8*](https://github.com/nixos/nixpkgs/compare/970e93b9f82e2a0f3675757eb0bfc73297cc6370...8f3e1f807051e32d8c95cd12b9b421623850a34d)
- [**nixvim**@*02505f2...6bd1c7c*](https://github.com/nix-community/nixvim/compare/02505f24b518e453bf523d235e6eed6c71f28142...6bd1c7c5927fa9fdfdfd68f5aa772e6a62b9d779)
- [**pre-commit-hooks**@*3308484...a5a9613*](https://github.com/cachix/pre-commit-hooks.nix/compare/3308484d1a443fc5bc92012435d79e80458fe43c...a5a961387e75ae44cc20f0a57ae463da5e959656)
- [**treefmt**@*6209c38...13c913f*](https://github.com/numtide/treefmt-nix/compare/6209c381904cab55796c5d7350e89681d3b2a8ef...13c913f5deb3a5c08bb810efd89dc8cb24dd968b)