### PR TITLE
flake: update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735344290,
-        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
+        "lastModified": 1736373539,
+        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
+        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1736012469,
-        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Output of `nix flake update`:
```
warning: updating lock file '/home/runner/work/nixcfg/nixcfg/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/613691f285dad87694c2ba1c9e6298d04736292d?narHash=sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM%3D' (2024-12-28)
  → 'github:nix-community/home-manager/bd65bc3cde04c16755955630b344bc9e35272c56?narHash=sha256-dinzAqCjenWDxuy%2BMqUQq0I4zUSfaCvN9rzuCmgMZJY%3D' (2025-01-08)
• Updated input 'nixpkgs-unstable':
    'github:nixos/nixpkgs/8f3e1f807051e32d8c95cd12b9b421623850a34d?narHash=sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs%2BrI%3D' (2025-01-04)
  → 'github:nixos/nixpkgs/bffc22eb12172e6db3c5dde9e3e5628f8e3e7912?narHash=sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc%2Bc2c%3D' (2025-01-08)
```

Output of `nix fmt`:
```
2025/01/09 14:36:39 INFO using config file: /nix/store/fkhz339vljrq5dazfanjxjvhqbzvmc26-treefmt.toml
traversed 77 files
emitted 43 files for processing
formatted 43 files (0 changed) in 1.287s
```

Comparison URLs:
- [**home-manager**@*613691f...bd65bc3*](https://github.com/nix-community/home-manager/compare/613691f285dad87694c2ba1c9e6298d04736292d...bd65bc3cde04c16755955630b344bc9e35272c56)
- [**nixpkgs-unstable**@*8f3e1f8...bffc22e*](https://github.com/nixos/nixpkgs/compare/8f3e1f807051e32d8c95cd12b9b421623850a34d...bffc22eb12172e6db3c5dde9e3e5628f8e3e7912)