### PR TITLE
flake: update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735774679,
-        "narHash": "sha256-soePLBazJk0qQdDVhdbM98vYdssfs3WFedcq+raipRI=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f2f7418ce0ab4a5309a4596161d154cfc877af66",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1736283893,
-        "narHash": "sha256-BG1FfTexFwNty5VhYjaQLMR6CMPfI3QRcaZrFQYu2EM=",
+        "lastModified": 1736441705,
+        "narHash": "sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb+mxySIP93o=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "4f339f6be2b61662f957c2ee9eda0fa597d8a6d6",
+        "rev": "8870dcaff63dfc6647fb10648b827e9d40b0a337",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736047960,
-        "narHash": "sha256-hutd85FA1jUJhhqBRRJ+u7UHO9oFGD/RVm2x5w8WjVQ=",
+        "lastModified": 1736440205,
+        "narHash": "sha256-QJgTI//KEGuEJC6FDxuI9Dq8PewIpnxD2NVx2/OHbfc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "816a6ae88774ba7e74314830546c29e134e0dffb",
+        "rev": "a2200b499efa01ca8646173e94cdfcc93188f2b8",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736200483,
-        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
+        "lastModified": 1736549401,
+        "narHash": "sha256-ibkQrMHxF/7TqAYcQE+tOnIsSEzXmMegzyBWza6uHKM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
+        "rev": "1dab772dd4a68a7bba5d9460685547ff8e17d899",
         "type": "github"
       },
       "original": {
@@ -182,11 +182,11 @@
         "treefmt-nix": []
       },
       "locked": {
-        "lastModified": 1735993984,
-        "narHash": "sha256-Syew+5yuzysUr07SrGD+GRfZjE11h36TSYbxzEHYyyc=",
+        "lastModified": 1736598792,
+        "narHash": "sha256-G6/9vT12RAxkNWQPEX9p8tTx/i8jJcmISpbVDGbEPGc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6bd1c7c5927fa9fdfdfd68f5aa772e6a62b9d779",
+        "rev": "2004ff4547f11d25da78f393fe797dde2b831ce7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Output of `nix flake update`:
```
warning: updating lock file '/home/runner/work/nixcfg/nixcfg/flake.lock':
• Updated input 'hardware':
    'github:nixos/nixos-hardware/4f339f6be2b61662f957c2ee9eda0fa597d8a6d6?narHash=sha256-BG1FfTexFwNty5VhYjaQLMR6CMPfI3QRcaZrFQYu2EM%3D' (2025-01-07)
  → 'github:nixos/nixos-hardware/8870dcaff63dfc6647fb10648b827e9d40b0a337?narHash=sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb%2BmxySIP93o%3D' (2025-01-09)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/816a6ae88774ba7e74314830546c29e134e0dffb?narHash=sha256-hutd85FA1jUJhhqBRRJ%2Bu7UHO9oFGD/RVm2x5w8WjVQ%3D' (2025-01-05)
  → 'github:nix-community/nix-index-database/a2200b499efa01ca8646173e94cdfcc93188f2b8?narHash=sha256-QJgTI//KEGuEJC6FDxuI9Dq8PewIpnxD2NVx2/OHbfc%3D' (2025-01-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3f0a8ac25fb674611b98089ca3a5dd6480175751?narHash=sha256-JO%2BlFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I%3D' (2025-01-06)
  → 'github:nixos/nixpkgs/1dab772dd4a68a7bba5d9460685547ff8e17d899?narHash=sha256-ibkQrMHxF/7TqAYcQE%2BtOnIsSEzXmMegzyBWza6uHKM%3D' (2025-01-10)
• Updated input 'nixvim':
    'github:nix-community/nixvim/6bd1c7c5927fa9fdfdfd68f5aa772e6a62b9d779?narHash=sha256-Syew%2B5yuzysUr07SrGD%2BGRfZjE11h36TSYbxzEHYyyc%3D' (2025-01-04)
  → 'github:nix-community/nixvim/2004ff4547f11d25da78f393fe797dde2b831ce7?narHash=sha256-G6/9vT12RAxkNWQPEX9p8tTx/i8jJcmISpbVDGbEPGc%3D' (2025-01-11)
• Updated input 'nixvim/flake-parts':
    'github:hercules-ci/flake-parts/f2f7418ce0ab4a5309a4596161d154cfc877af66?narHash=sha256-soePLBazJk0qQdDVhdbM98vYdssfs3WFedcq%2BraipRI%3D' (2025-01-01)
  → 'github:hercules-ci/flake-parts/b905f6fc23a9051a6e1b741e1438dbfc0634c6de?narHash=sha256-%2Bhu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU%3D' (2025-01-06)
```

Output of `nix fmt`:
```
2025/01/12 01:25:19 INFO using config file: /nix/store/fkhz339vljrq5dazfanjxjvhqbzvmc26-treefmt.toml
traversed 91 files
emitted 55 files for processing
formatted 55 files (0 changed) in 1.439s
```

Comparison URLs:
- [**flake-parts**@*f2f7418...b905f6f*](https://github.com/hercules-ci/flake-parts/compare/f2f7418ce0ab4a5309a4596161d154cfc877af66...b905f6fc23a9051a6e1b741e1438dbfc0634c6de)
- [**hardware**@*4f339f6...8870dca*](https://github.com/nixos/nixos-hardware/compare/4f339f6be2b61662f957c2ee9eda0fa597d8a6d6...8870dcaff63dfc6647fb10648b827e9d40b0a337)
- [**nix-index-database**@*816a6ae...a2200b4*](https://github.com/nix-community/nix-index-database/compare/816a6ae88774ba7e74314830546c29e134e0dffb...a2200b499efa01ca8646173e94cdfcc93188f2b8)
- [**nixpkgs**@*3f0a8ac...1dab772*](https://github.com/nixos/nixpkgs/compare/3f0a8ac25fb674611b98089ca3a5dd6480175751...1dab772dd4a68a7bba5d9460685547ff8e17d899)
- [**nixvim**@*6bd1c7c...2004ff4*](https://github.com/nix-community/nixvim/compare/6bd1c7c5927fa9fdfdfd68f5aa772e6a62b9d779...2004ff4547f11d25da78f393fe797dde2b831ce7)