### PR TITLE
flake: update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734088167,
-        "narHash": "sha256-snPBgTqwn3FPZVdFC5yt7Bnk3squim1vZOZ8CObWykk=",
+        "lastModified": 1736864502,
+        "narHash": "sha256-ItkIZyebGvNH2dK9jVGzJHGPtb6BSWLN8Gmef16NeY0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "65a441502c9382d41ada1adbc9bd31d6c9b00fe2",
+        "rev": "0141aabed359f063de7413f80d906e1d98c0c123",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1736441705,
-        "narHash": "sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb+mxySIP93o=",
+        "lastModified": 1736978406,
+        "narHash": "sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "8870dcaff63dfc6647fb10648b827e9d40b0a337",
+        "rev": "b678606690027913f3434dea3864e712b862dde5",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736440205,
-        "narHash": "sha256-QJgTI//KEGuEJC6FDxuI9Dq8PewIpnxD2NVx2/OHbfc=",
+        "lastModified": 1736652904,
+        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "a2200b499efa01ca8646173e94cdfcc93188f2b8",
+        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736549401,
-        "narHash": "sha256-ibkQrMHxF/7TqAYcQE+tOnIsSEzXmMegzyBWza6uHKM=",
+        "lastModified": 1737165118,
+        "narHash": "sha256-s40Kk/OulP3J/1JvC3VT16U4r/Xw6Qdi7SRw3LYkPWs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1dab772dd4a68a7bba5d9460685547ff8e17d899",
+        "rev": "6a3ae7a5a12fb8cac2d59d7df7cbd95f9b2f0566",
         "type": "github"
       },
       "original": {
@@ -186,11 +186,11 @@
         "treefmt-nix": []
       },
       "locked": {
-        "lastModified": 1736598792,
-        "narHash": "sha256-G6/9vT12RAxkNWQPEX9p8tTx/i8jJcmISpbVDGbEPGc=",
+        "lastModified": 1737141914,
+        "narHash": "sha256-Lq7PWAD+edeIpZKM7aresrwON+Tdo3OMu1S2YX8AjjM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2004ff4547f11d25da78f393fe797dde2b831ce7",
+        "rev": "c2ee71c814c9427d4991b9d58d412add9c5a1c56",
         "type": "github"
       },
       "original": {
@@ -209,11 +209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735882644,
-        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
+        "lastModified": 1737043064,
+        "narHash": "sha256-I/OuxGwXwRi5gnFPsyCvVR+IfFstA+QXEpHu1hvsgD8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
+        "rev": "94ee657f6032d913fe0ef49adaa743804635b0bb",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736154270,
-        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
+        "lastModified": 1737103437,
+        "narHash": "sha256-uPNWcYbhY2fjY3HOfRCR5jsfzdzemhfxLSxwjXYXqNc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
+        "rev": "d1ed3b385f8130e392870cfb1dbfaff8a63a1899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Output of `nix flake update`:
```
warning: updating lock file '/home/runner/work/nixcfg/nixcfg/flake.lock':
• Updated input 'disko':
    'github:nix-community/disko/65a441502c9382d41ada1adbc9bd31d6c9b00fe2?narHash=sha256-snPBgTqwn3FPZVdFC5yt7Bnk3squim1vZOZ8CObWykk%3D' (2024-12-13)
  → 'github:nix-community/disko/0141aabed359f063de7413f80d906e1d98c0c123?narHash=sha256-ItkIZyebGvNH2dK9jVGzJHGPtb6BSWLN8Gmef16NeY0%3D' (2025-01-14)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/8870dcaff63dfc6647fb10648b827e9d40b0a337?narHash=sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb%2BmxySIP93o%3D' (2025-01-09)
  → 'github:nixos/nixos-hardware/b678606690027913f3434dea3864e712b862dde5?narHash=sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk%3D' (2025-01-15)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/a2200b499efa01ca8646173e94cdfcc93188f2b8?narHash=sha256-QJgTI//KEGuEJC6FDxuI9Dq8PewIpnxD2NVx2/OHbfc%3D' (2025-01-09)
  → 'github:nix-community/nix-index-database/271e5bd7c57e1f001693799518b10a02d1123b12?narHash=sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM%3D' (2025-01-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1dab772dd4a68a7bba5d9460685547ff8e17d899?narHash=sha256-ibkQrMHxF/7TqAYcQE%2BtOnIsSEzXmMegzyBWza6uHKM%3D' (2025-01-10)
  → 'github:nixos/nixpkgs/6a3ae7a5a12fb8cac2d59d7df7cbd95f9b2f0566?narHash=sha256-s40Kk/OulP3J/1JvC3VT16U4r/Xw6Qdi7SRw3LYkPWs%3D' (2025-01-18)
• Updated input 'nixvim':
    'github:nix-community/nixvim/2004ff4547f11d25da78f393fe797dde2b831ce7?narHash=sha256-G6/9vT12RAxkNWQPEX9p8tTx/i8jJcmISpbVDGbEPGc%3D' (2025-01-11)
  → 'github:nix-community/nixvim/c2ee71c814c9427d4991b9d58d412add9c5a1c56?narHash=sha256-Lq7PWAD%2BedeIpZKM7aresrwON%2BTdo3OMu1S2YX8AjjM%3D' (2025-01-17)
• Updated input 'pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/a5a961387e75ae44cc20f0a57ae463da5e959656?narHash=sha256-3FZAG%2BpGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110%3D' (2025-01-03)
  → 'github:cachix/pre-commit-hooks.nix/94ee657f6032d913fe0ef49adaa743804635b0bb?narHash=sha256-I/OuxGwXwRi5gnFPsyCvVR%2BIfFstA%2BQXEpHu1hvsgD8%3D' (2025-01-16)
• Updated input 'treefmt':
    'github:numtide/treefmt-nix/13c913f5deb3a5c08bb810efd89dc8cb24dd968b?narHash=sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw%3D' (2025-01-06)
  → 'github:numtide/treefmt-nix/d1ed3b385f8130e392870cfb1dbfaff8a63a1899?narHash=sha256-uPNWcYbhY2fjY3HOfRCR5jsfzdzemhfxLSxwjXYXqNc%3D' (2025-01-17)
```

Output of `nix fmt`:
```
2025/01/19 01:21:12 INFO using config file: /nix/store/xmpif9vn14ps7dw56baxmrk7dk4i0r93-treefmt.toml
traversed 100 files
emitted 63 files for processing
formatted 63 files (0 changed) in 1.89s
```

Comparison URLs:
- [**disko**@*65a4415...0141aab*](https://github.com/nix-community/disko/compare/65a441502c9382d41ada1adbc9bd31d6c9b00fe2...0141aabed359f063de7413f80d906e1d98c0c123)
- [**hardware**@*8870dca...b678606*](https://github.com/nixos/nixos-hardware/compare/8870dcaff63dfc6647fb10648b827e9d40b0a337...b678606690027913f3434dea3864e712b862dde5)
- [**nix-index-database**@*a2200b4...271e5bd*](https://github.com/nix-community/nix-index-database/compare/a2200b499efa01ca8646173e94cdfcc93188f2b8...271e5bd7c57e1f001693799518b10a02d1123b12)
- [**nixpkgs**@*1dab772...6a3ae7a*](https://github.com/nixos/nixpkgs/compare/1dab772dd4a68a7bba5d9460685547ff8e17d899...6a3ae7a5a12fb8cac2d59d7df7cbd95f9b2f0566)
- [**nixvim**@*2004ff4...c2ee71c*](https://github.com/nix-community/nixvim/compare/2004ff4547f11d25da78f393fe797dde2b831ce7...c2ee71c814c9427d4991b9d58d412add9c5a1c56)
- [**pre-commit-hooks**@*a5a9613...94ee657*](https://github.com/cachix/pre-commit-hooks.nix/compare/a5a961387e75ae44cc20f0a57ae463da5e959656...94ee657f6032d913fe0ef49adaa743804635b0bb)
- [**treefmt**@*13c913f...d1ed3b3*](https://github.com/numtide/treefmt-nix/compare/13c913f5deb3a5c08bb810efd89dc8cb24dd968b...d1ed3b385f8130e392870cfb1dbfaff8a63a1899)