### PR TITLE
flake: update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1736978406,
-        "narHash": "sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk=",
+        "lastModified": 1737590910,
+        "narHash": "sha256-qM/y6Dtpu9Wmf5HqeZajQdn+cS0aljdYQQQnrvx+LJE=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "b678606690027913f3434dea3864e712b862dde5",
+        "rev": "9368027715d8dde4b84c79c374948b5306fdd2db",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736652904,
-        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
+        "lastModified": 1737257306,
+        "narHash": "sha256-lEGgpA4kGafc76+Amnz+gh1L/cwUS2pePFlf22WEyh8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
+        "rev": "744d330659e207a1883d2da0141d35e520eb87bd",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737165118,
-        "narHash": "sha256-s40Kk/OulP3J/1JvC3VT16U4r/Xw6Qdi7SRw3LYkPWs=",
+        "lastModified": 1737569578,
+        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6a3ae7a5a12fb8cac2d59d7df7cbd95f9b2f0566",
+        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737141914,
-        "narHash": "sha256-Lq7PWAD+edeIpZKM7aresrwON+Tdo3OMu1S2YX8AjjM=",
+        "lastModified": 1737283156,
+        "narHash": "sha256-FyHmM6vvz+UxCrPZo/poIaZBZejLHVKkAH4cjtUxZDA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c2ee71c814c9427d4991b9d58d412add9c5a1c56",
+        "rev": "abcbd250b8a2c7aab1f4b2b9e01598ee24b42337",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737043064,
-        "narHash": "sha256-I/OuxGwXwRi5gnFPsyCvVR+IfFstA+QXEpHu1hvsgD8=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "94ee657f6032d913fe0ef49adaa743804635b0bb",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737103437,
-        "narHash": "sha256-uPNWcYbhY2fjY3HOfRCR5jsfzdzemhfxLSxwjXYXqNc=",
+        "lastModified": 1737483750,
+        "narHash": "sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "d1ed3b385f8130e392870cfb1dbfaff8a63a1899",
+        "rev": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Output of `nix flake update`:
```
warning: updating lock file '/home/runner/work/nixcfg/nixcfg/flake.lock':
• Updated input 'hardware':
    'github:nixos/nixos-hardware/b678606690027913f3434dea3864e712b862dde5?narHash=sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk%3D' (2025-01-15)
  → 'github:nixos/nixos-hardware/9368027715d8dde4b84c79c374948b5306fdd2db?narHash=sha256-qM/y6Dtpu9Wmf5HqeZajQdn%2BcS0aljdYQQQnrvx%2BLJE%3D' (2025-01-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/271e5bd7c57e1f001693799518b10a02d1123b12?narHash=sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM%3D' (2025-01-12)
  → 'github:nix-community/nix-index-database/744d330659e207a1883d2da0141d35e520eb87bd?narHash=sha256-lEGgpA4kGafc76%2BAmnz%2Bgh1L/cwUS2pePFlf22WEyh8%3D' (2025-01-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6a3ae7a5a12fb8cac2d59d7df7cbd95f9b2f0566?narHash=sha256-s40Kk/OulP3J/1JvC3VT16U4r/Xw6Qdi7SRw3LYkPWs%3D' (2025-01-18)
  → 'github:nixos/nixpkgs/47addd76727f42d351590c905d9d1905ca895b82?narHash=sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB%2Bf3M%3D' (2025-01-22)
• Updated input 'nixvim':
    'github:nix-community/nixvim/c2ee71c814c9427d4991b9d58d412add9c5a1c56?narHash=sha256-Lq7PWAD%2BedeIpZKM7aresrwON%2BTdo3OMu1S2YX8AjjM%3D' (2025-01-17)
  → 'github:nix-community/nixvim/abcbd250b8a2c7aab1f4b2b9e01598ee24b42337?narHash=sha256-FyHmM6vvz%2BUxCrPZo/poIaZBZejLHVKkAH4cjtUxZDA%3D' (2025-01-19)
• Updated input 'pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/94ee657f6032d913fe0ef49adaa743804635b0bb?narHash=sha256-I/OuxGwXwRi5gnFPsyCvVR%2BIfFstA%2BQXEpHu1hvsgD8%3D' (2025-01-16)
  → 'github:cachix/pre-commit-hooks.nix/9364dc02281ce2d37a1f55b6e51f7c0f65a75f17?narHash=sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg%3D' (2025-01-21)
• Updated input 'treefmt':
    'github:numtide/treefmt-nix/d1ed3b385f8130e392870cfb1dbfaff8a63a1899?narHash=sha256-uPNWcYbhY2fjY3HOfRCR5jsfzdzemhfxLSxwjXYXqNc%3D' (2025-01-17)
  → 'github:numtide/treefmt-nix/f2cc121df15418d028a59c9737d38e3a90fbaf8f?narHash=sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo%3D' (2025-01-21)
```

Output of `nix fmt`:
```
2025/01/24 13:26:31 INFO using config file: /nix/store/xmpif9vn14ps7dw56baxmrk7dk4i0r93-treefmt.toml
traversed 108 files
emitted 71 files for processing
formatted 71 files (0 changed) in 1.967s
```

Comparison URLs:
- [**hardware**@*b678606...9368027*](https://github.com/nixos/nixos-hardware/compare/b678606690027913f3434dea3864e712b862dde5...9368027715d8dde4b84c79c374948b5306fdd2db)
- [**nix-index-database**@*271e5bd...744d330*](https://github.com/nix-community/nix-index-database/compare/271e5bd7c57e1f001693799518b10a02d1123b12...744d330659e207a1883d2da0141d35e520eb87bd)
- [**nixpkgs**@*6a3ae7a...47addd7*](https://github.com/nixos/nixpkgs/compare/6a3ae7a5a12fb8cac2d59d7df7cbd95f9b2f0566...47addd76727f42d351590c905d9d1905ca895b82)
- [**nixvim**@*c2ee71c...abcbd25*](https://github.com/nix-community/nixvim/compare/c2ee71c814c9427d4991b9d58d412add9c5a1c56...abcbd250b8a2c7aab1f4b2b9e01598ee24b42337)
- [**pre-commit-hooks**@*94ee657...9364dc0*](https://github.com/cachix/pre-commit-hooks.nix/compare/94ee657f6032d913fe0ef49adaa743804635b0bb...9364dc02281ce2d37a1f55b6e51f7c0f65a75f17)
- [**treefmt**@*d1ed3b3...f2cc121*](https://github.com/numtide/treefmt-nix/compare/d1ed3b385f8130e392870cfb1dbfaff8a63a1899...f2cc121df15418d028a59c9737d38e3a90fbaf8f)