### PR TITLE
flake: update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1737590910,
-        "narHash": "sha256-qM/y6Dtpu9Wmf5HqeZajQdn+cS0aljdYQQQnrvx+LJE=",
+        "lastModified": 1737751639,
+        "narHash": "sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "9368027715d8dde4b84c79c374948b5306fdd2db",
+        "rev": "dfad538f751a5aa5d4436d9781ab27a6128ec9d4",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737569578,
-        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
+        "lastModified": 1737672001,
+        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
+        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737283156,
-        "narHash": "sha256-FyHmM6vvz+UxCrPZo/poIaZBZejLHVKkAH4cjtUxZDA=",
+        "lastModified": 1737731711,
+        "narHash": "sha256-6ubhKkCkBMuqFMjzeg+/2L5dNipKKf1KE9i8r8inyEg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "abcbd250b8a2c7aab1f4b2b9e01598ee24b42337",
+        "rev": "841155edf9c4578f2f9a7bd6993e1da2ce73b35c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Output of `nix flake update`:
```
warning: updating lock file '/home/runner/work/nixcfg/nixcfg/flake.lock':
• Updated input 'hardware':
    'github:nixos/nixos-hardware/9368027715d8dde4b84c79c374948b5306fdd2db?narHash=sha256-qM/y6Dtpu9Wmf5HqeZajQdn%2BcS0aljdYQQQnrvx%2BLJE%3D' (2025-01-23)
  → 'github:nixos/nixos-hardware/dfad538f751a5aa5d4436d9781ab27a6128ec9d4?narHash=sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4%3D' (2025-01-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/47addd76727f42d351590c905d9d1905ca895b82?narHash=sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB%2Bf3M%3D' (2025-01-22)
  → 'github:nixos/nixpkgs/035f8c0853c2977b24ffc4d0a42c74f00b182cd8?narHash=sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I%3D' (2025-01-23)
• Updated input 'nixvim':
    'github:nix-community/nixvim/abcbd250b8a2c7aab1f4b2b9e01598ee24b42337?narHash=sha256-FyHmM6vvz%2BUxCrPZo/poIaZBZejLHVKkAH4cjtUxZDA%3D' (2025-01-19)
  → 'github:nix-community/nixvim/841155edf9c4578f2f9a7bd6993e1da2ce73b35c?narHash=sha256-6ubhKkCkBMuqFMjzeg%2B/2L5dNipKKf1KE9i8r8inyEg%3D' (2025-01-24)
```

Output of `nix fmt`:
```
2025/01/26 01:18:18 INFO using config file: /nix/store/xmpif9vn14ps7dw56baxmrk7dk4i0r93-treefmt.toml
traversed 108 files
emitted 71 files for processing
formatted 71 files (0 changed) in 1.869s
```

Comparison URLs:
- [**hardware**@*9368027...dfad538*](https://github.com/nixos/nixos-hardware/compare/9368027715d8dde4b84c79c374948b5306fdd2db...dfad538f751a5aa5d4436d9781ab27a6128ec9d4)
- [**nixpkgs**@*47addd7...035f8c0*](https://github.com/nixos/nixpkgs/compare/47addd76727f42d351590c905d9d1905ca895b82...035f8c0853c2977b24ffc4d0a42c74f00b182cd8)
- [**nixvim**@*abcbd25...841155e*](https://github.com/nix-community/nixvim/compare/abcbd250b8a2c7aab1f4b2b9e01598ee24b42337...841155edf9c4578f2f9a7bd6993e1da2ce73b35c)